### PR TITLE
[AP-809] Fix thread_ts values in messages and threads streams

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -257,7 +257,7 @@ class ConversationHistoryStream(SlackStream):
                                     # If threads are being synced then the message data for the
                                     # message the threaded replies are in response to will be
                                     # synced to the messages table as well as the threads table
-                                    if threads_stream:
+                                    if threads_stream and data.get('thread_ts'):
                                         # If threads is selected we need to sync all the
                                         # threaded replies to this message
                                         threads_stream.write_schema()
@@ -274,9 +274,7 @@ class ConversationHistoryStream(SlackStream):
                                             schema=schema,
                                             metadata=metadata.to_map(mdata)
                                         )
-                                        record_timestamp = \
-                                            transformed_record.get('thread_ts', '').partition('.')[
-                                                0]
+                                        record_timestamp = data.get('ts', '').partition('.')[0]
                                         record_timestamp_int = int(record_timestamp)
                                         if record_timestamp_int >= start.timestamp():
                                             if self.write_to_singer:

--- a/tap_slack/transform.py
+++ b/tap_slack/transform.py
@@ -33,9 +33,5 @@ def transform_json(stream, data, date_fields, channel_id=None):
             for date_field in date_fields:
                 timestamp = record.get(date_field, None)
                 if timestamp and isinstance(timestamp, str):
-                    if stream == 'messages' or stream == "threads" and date_field == 'ts':
-                        record['thread_ts'] = timestamp
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
-                    else:
-                        record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
+                    record[date_field] = decimal_timestamp_to_utc_timestamp(timestamp)
     return data


### PR DESCRIPTION
## Problem

`thread_ts` values in the `messages` and `threads` streams are not populating correctly.

## Proposed changes

`thread_ts` is the link between `messages` and `threads`. The slack API `conversations.history` endpoint returns `thread_ts` if the message has a thread otherwise the API doesn't return this key. The PR pulls threads from the `conversations.replies` endpoint only if `thread_ts` received from `conversations.history` endpoint.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions