### PR TITLE
[AP-865] Extract message attachements from conversations.history resp…

### DIFF
--- a/tap_slack/schemas/messages.json
+++ b/tap_slack/schemas/messages.json
@@ -77,6 +77,24 @@
         "object"
       ]
     },
+    "attachments": {
+      "title": [
+        "null",
+        "string"
+      ],
+      "id": [
+        "null",
+        "integer"
+      ],
+      "color": [
+        "null",
+        "string"
+      ],
+      "fallback": [
+        "null",
+        "string"
+      ]
+    },
     "client_msg_id": {
       "type": [
         "null",


### PR DESCRIPTION
## Problem

Attachments are not extracted from `conversations.history` JSON responses.

## Proposed changes

Modify the messages json schema to extract the attachments and to add it to the singer record messages.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions