### PR TITLE
[AP-865] Fix attachments schema

### DIFF
--- a/tap_slack/schemas/messages.json
+++ b/tap_slack/schemas/messages.json
@@ -78,21 +78,33 @@
       ]
     },
     "attachments": {
-      "title": [
+      "items": {
+        "properties": {
+          "title": [
+            "null",
+            "string"
+          ],
+          "id": [
+            "null",
+            "integer"
+          ],
+          "color": [
+            "null",
+            "string"
+          ],
+          "fallback": [
+            "null",
+            "string"
+          ]
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      },
+      "type": [
         "null",
-        "string"
-      ],
-      "id": [
-        "null",
-        "integer"
-      ],
-      "color": [
-        "null",
-        "string"
-      ],
-      "fallback": [
-        "null",
-        "string"
+        "array"
       ]
     },
     "client_msg_id": {

--- a/tap_slack/schemas/messages.json
+++ b/tap_slack/schemas/messages.json
@@ -80,22 +80,30 @@
     "attachments": {
       "items": {
         "properties": {
-          "title": [
-            "null",
-            "string"
-          ],
-          "id": [
-            "null",
-            "integer"
-          ],
-          "color": [
-            "null",
-            "string"
-          ],
-          "fallback": [
-            "null",
-            "string"
-          ]
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "color": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "fallback": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
         },
         "type": [
           "null",


### PR DESCRIPTION
## Problem

JSON schema doesn't match to the actual slack API responses.

## Proposed changes

Define `attachments` as array in the messages json schema

**Note:** Unit tests are missing because we need to refactor the entire testing mechanism. The current test env relies on the non-public singer docker image with non-public tap-tester scripts. Further info [here](https://github.com/singer-io/tap-slack/blob/d672fed6ec87286788fad228ebeb2f04bbb75992/.circleci/config.yml#L5) and [here](https://github.com/singer-io/tap-slack/blob/d672fed6ec87286788fad228ebeb2f04bbb75992/.circleci/config.yml#L22)
 
## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions