### PR TITLE
[AP-860] Update bookmark correctly

### DIFF
--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -299,7 +299,7 @@ class ConversationHistoryStream(SlackStream):
                                                 min_bookmark = datetime.fromtimestamp(
                                                     record_timestamp_int)
                                 self.update_bookmarks(channel_id,
-                                                      min_bookmark.strftime(DATETIME_FORMAT))
+                                                      max_bookmark.strftime(DATETIME_FORMAT))
                             # Update the date window
                             date_window_start = date_window_end
                             date_window_end = date_window_start + timedelta(

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -537,7 +537,7 @@ class FilesStream(SlackStream):
                                         # newest -> oldest
                                         min_bookmark = datetime.fromtimestamp(
                                             record_timestamp_int)
-                        self.update_bookmarks(self.name, min_bookmark.strftime(DATETIME_FORMAT))
+                        self.update_bookmarks(self.name, max_bookmark.strftime(DATETIME_FORMAT))
                     # Update the date window
                     date_window_start = date_window_end
                     date_window_end = date_window_start + timedelta(
@@ -617,7 +617,7 @@ class RemoteFilesStream(SlackStream):
                                         # newest -> oldest
                                         min_bookmark = datetime.fromtimestamp(
                                             record_timestamp_int)
-                        self.update_bookmarks(self.name, min_bookmark.strftime(DATETIME_FORMAT))
+                        self.update_bookmarks(self.name, max_bookmark.strftime(DATETIME_FORMAT))
                     # Update the date window
                     date_window_start = date_window_end
                     date_window_end = date_window_start + timedelta(


### PR DESCRIPTION
## Problem

Bookmarks of incrementally loaded streams are not updating correctly and they're always the start date of the generated absolute date range.

## Proposed changes

Use the value of the `max_bookmark` instead of `min_bookmark` in the STATE message. `max_bookmark` is a rolling timestamp with the last extracted message received from the slack API and the ideal timestamp for incremental load.

**Note:** Unit tests are missing because we need to refactor the entire testing mechanism. The current test env relies on the non-public singer docker image with non-public tap-tester scripts. Further info [here](https://github.com/singer-io/tap-slack/blob/d672fed6ec87286788fad228ebeb2f04bbb75992/.circleci/config.yml#L5) and [here](https://github.com/singer-io/tap-slack/blob/d672fed6ec87286788fad228ebeb2f04bbb75992/.circleci/config.yml#L22)

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions