### PR TITLE
AP-1335 circumvent rate limits in users endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
 
     steps:
       - name: Checkout repository

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='pipelinewise-tap-slack',
       py_modules=['tap_slack'],
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'slackclient==2.6.0',
+          'slack-sdk==3.20.0',
       ],
       extras_require={
           'test': [

--- a/tap_slack/__init__.py
+++ b/tap_slack/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import json
 import singer
-from slack import WebClient
+from slack_sdk import WebClient
 
 from tap_slack.client import SlackClient
 from tap_slack.streams import AVAILABLE_STREAMS

--- a/tap_slack/__init__.py
+++ b/tap_slack/__init__.py
@@ -7,7 +7,7 @@ from tap_slack.client import SlackClient
 from tap_slack.streams import AVAILABLE_STREAMS
 from tap_slack.catalog import generate_catalog
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger(__name__)
 
 
 def auto_join(client, config):

--- a/tap_slack/client.py
+++ b/tap_slack/client.py
@@ -6,7 +6,7 @@ import time
 
 import backoff
 import singer
-from slack.errors import SlackApiError
+from slack_sdk.errors import SlackApiError
 
 LOGGER = singer.get_logger()
 

--- a/tap_slack/client.py
+++ b/tap_slack/client.py
@@ -8,7 +8,7 @@ import backoff
 import singer
 from slack_sdk.errors import SlackApiError
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger(__name__)
 
 
 class SlackClient(object):

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -331,8 +331,12 @@ class UsersStream(SlackStream):
         # pylint: disable=unused-variable
         with singer.metrics.job_timer(job_type='list_users') as timer:
             with singer.metrics.record_counter(endpoint=self.name) as counter:
-                users_list = self.client.get_users(limit=100)
+                # API returns users in no particular order.
+                # let's fetch 1000 users per page for now, it saves on api requests and avoids running
+                # into rate limiting soon
+                users_list = self.client.get_users(limit=1000)
 
+                # this will encounter rate limit at some point
                 for page in users_list:
                     users = page.get('members')
                     transformed_users = transform_json(stream=self.name, data=users,

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -8,7 +8,7 @@ from singer.utils import strptime_to_utc
 
 from tap_slack.transform import transform_json
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger(__name__)
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 utc = pytz.UTC
 


### PR DESCRIPTION
## Problem

Iterating through user pages end up running into rate limiting

## Proposed changes

quick fix is to increase page size to 1000 which is the default and max of the slack API.

### Miscellenous changes:
* Change from deprecated `slackclient` to recommend `slack-sdk` which has a similar APIs.
* 3.6 in CI fails 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
